### PR TITLE
returning empty string rather than null 

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -37,5 +37,5 @@ jQuery.cookie = function (key, value, options) {
     // key and possibly options given, get cookie...
     options = value || {};
     var result, decode = options.raw ? function (s) { return s; } : decodeURIComponent;
-    return (result = new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)').exec(document.cookie)) ? decode(result[1]) : null;
+    return (result = new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)').exec(document.cookie)) ? decode(result[1]) : "";
 };


### PR DESCRIPTION
returning empty string rather than null - to avoid ie issues when returning null
