### PR TITLE
Sonderzeichen in Cookies nicht htmlcodieren um Platz zu sparen

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -26,7 +26,7 @@ jQuery.cookie = function (key, value, options) {
 
         return (document.cookie = [
             encodeURIComponent(key), '=',
-            options.raw ? value : encodeURIComponent(value),
+            options.raw ? value : cookie_encode(value),
             options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
             options.path ? '; path=' + options.path : '',
             options.domain ? '; domain=' + options.domain : '',
@@ -39,3 +39,11 @@ jQuery.cookie = function (key, value, options) {
     var result, decode = options.raw ? function (s) { return s; } : decodeURIComponent;
     return (result = new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)').exec(document.cookie)) ? decode(result[1]) : null;
 };
+
+function cookie_encode(string){
+    //full uri decode not only to encode ",; =" but to save uicode charaters
+	var decoded = encodeURIComponent(string);
+	//encode back common and allowed charaters {}:"#[] to save space and make the cookies more human readable
+	var ns = decoded.replace(/(%7B|%7D|%3A|%22|%23|%5B|%5D)/g,function(charater){return decodeURIComponent(charater);});
+	return ns;
+}


### PR DESCRIPTION
Hallo, ich benutze schon länger eine angepassste Version von jquery.cookie um ein paar bytes zu sparen und die cookies schneller debuggen zu können.

Es dekodiert bestimmte Zeichen {}:"#[] die in cookies erlaubt sind nicht mit encodeURIComponent bzw. dekodiert diese vor dem speichern.

Das Programm ist zwar größer aber dafür sind die cookies kleiner wenn Zeichen wie z.B. geschweifte Klammern vorkommen. 

Da beim Lesen der cookies decodeURIComponent verwendet wird, gibt es keine kompatibilitäts Probleme mit bereits gesetzten Cookies (zumndest sind mir keine bekannt).

Bei der Serverseitigenverarbeitung sollte das gleiche gelten bzw. dort sollte es sogar in einigen fällen dazu führen das jquery.cookie kompatibler wird mit Servern die die cookies garnicht oder auch nur teilweise uri-kodieren.

Viele Grüße
