### PR TITLE
Wrap jquery-cookie in a closure

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -7,35 +7,37 @@
  * http://www.gnu.org/licenses/gpl.html
  *
  */
-jQuery.cookie = function (key, value, options) {
+(function($) {
+    $.cookie = function (key, value, options) {
 
-    // key and at least value given, set cookie...
-    if (arguments.length > 1 && String(value) !== "[object Object]") {
-        options = jQuery.extend({}, options);
+        // key and at least value given, set cookie...
+        if (arguments.length > 1 && String(value) !== "[object Object]") {
+            options = $.extend({}, options);
 
-        if (value === null || value === undefined) {
-            options.expires = -1;
+            if (value === null || value === undefined) {
+                options.expires = -1;
+            }
+
+            if (typeof options.expires === 'number') {
+                var days = options.expires, t = options.expires = new Date();
+                t.setDate(t.getDate() + days);
+            }
+
+            value = String(value);
+
+            return (document.cookie = [
+                encodeURIComponent(key), '=',
+                options.raw ? value : encodeURIComponent(value),
+                options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+                options.path ? '; path=' + options.path : '',
+                options.domain ? '; domain=' + options.domain : '',
+                options.secure ? '; secure' : ''
+            ].join(''));
         }
 
-        if (typeof options.expires === 'number') {
-            var days = options.expires, t = options.expires = new Date();
-            t.setDate(t.getDate() + days);
-        }
-
-        value = String(value);
-
-        return (document.cookie = [
-            encodeURIComponent(key), '=',
-            options.raw ? value : encodeURIComponent(value),
-            options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
-            options.path ? '; path=' + options.path : '',
-            options.domain ? '; domain=' + options.domain : '',
-            options.secure ? '; secure' : ''
-        ].join(''));
-    }
-
-    // key and possibly options given, get cookie...
-    options = value || {};
-    var result, decode = options.raw ? function (s) { return s; } : decodeURIComponent;
-    return (result = new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)').exec(document.cookie)) ? decode(result[1]) : null;
-};
+        // key and possibly options given, get cookie...
+        options = value || {};
+        var result, decode = options.raw ? function (s) { return s; } : decodeURIComponent;
+        return (result = new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)').exec(document.cookie)) ? decode(result[1]) : null;
+    };
+})(jQuery);


### PR DESCRIPTION
I've updated jquery-cookie to use a closure as the following will fail when you want jQuery to relinquish control of the jQuery variable:

``` javascript
var old_jQuery = $.noConflict(true);
$.cookie("test");
/* Uncaught TypeError: Cannot call method 'extend' of undefined */
```
