### PR TITLE
Adds RFC2068 quoted string decoding

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -36,11 +36,24 @@
 
         // key and possibly options given, get cookie...
         options = value || {};
-        var decode = options.raw ? function(s) { return s; } : decodeURIComponent;
+        var rawreturn = function(s) { return s; };
+        var decode = options.raw ? rawreturn : decodeURIComponent;
+        var un_rfc2068 = options.raw ? rawreturn : function(value) {
+            if (value.indexOf('"') === 0) {
+                // This is a quoted cookie as according to RFC2068, unescape
+                value = value.substr(1, value.length - 2);  // Remove the leading and trailing "
+                value = value.replace('\\"', '"');
+                value = value.replace('\\\\', '\\');
+            }
+            return value;
+        };
 
-        var pairs = document.cookie.split('; ');
+        var value, pairs = document.cookie.split('; ');
         for (var i = 0, pair; pair = pairs[i] && pairs[i].split('='); i++) {
-            if (decode(pair[0]) === key) return decode(pair[1] || ''); // IE saves cookies with empty string as "c; ", e.g. without "=" as opposed to EOMB, thus pair[1] may be undefined
+            if (decode(pair[0]) === key) {
+                // IE saves cookies with empty string as "c; ", e.g. without "=" as opposed to EOMB, thus pair[1] may be undefined
+                return un_rfc2068(decode(pair[1] || ''));
+            }
         }
         return null;
     };

--- a/test.js
+++ b/test.js
@@ -29,9 +29,14 @@ test('decode', 1, function () {
     equal($.cookie(' c'), ' v', 'should decode key and value');
 });
 
+test('rfc2068', 1, function () {
+    document.cookie = 'c="v@address.com\\"\\\\"';
+    equal($.cookie('c'), 'v@address.com"\\', 'should decode rfc2068 quoted string');
+});
+
 test('raw: true', 1, function () {
-    document.cookie = 'c=%20v';
-    equal($.cookie('c', { raw: true }), '%20v', 'should not decode');
+    document.cookie = 'c=%20v"\\';
+    equal($.cookie('c', { raw: true }), '%20v"\\', 'should not decode');
 });
 
 


### PR DESCRIPTION
With a cookie like this:

```
Cookie: mycookie="robmadole@gmail.com";
```

The quotes are not removed when the value is returned.

This cookie would also cause a problem:

```
Cookie: mycookie="A value with \" and \\";
```

This pull request adds the decoding of the escaped characters and removes the leading and trailing quote.
