### PR TITLE
Added support for `domain: 'all'` which sets the cookie on the top most domain possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Define the path where cookie is valid. *By default the path of the cookie is the
 
 Default: domain of page where the cookie was created.
 
+Use `domain: 'all'` to set the cookie on the top most level domain possible. Useful if you need to share cookies between subdomains in a generic manner.
+
     secure: true
 
 Default: `false`. If true, the cookie transmission requires a secure protocol (https).

--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -23,6 +23,12 @@
                 t.setDate(t.getDate() + days);
             }
 
+            if (options.domain === 'all') { // set cookie on top most domain
+                var hostname = options.hostname || window.location.hostname, // allows overriding hostname via options, mainly for testability
+                    match = hostname.match(/[^.]*\.([^.]*|..\...|...\...)$/);
+                options.domain = match ? "." + match[0] : hostname;
+            }
+
             value = String(value);
 
             return (document.cookie = [

--- a/test.js
+++ b/test.js
@@ -66,6 +66,20 @@ test('raw: true', 1, function () {
         ' v', 'should not encode');
 });
 
+test('domain', 1, function () {
+    equal($.cookie('c', ' v', { domain: "test.com" }).split('=')[2],
+        'test.com', 'should set domain');
+});
+
+test('domain: all', 3, function () {
+    equal($.cookie('c', ' v', { domain: "all", hostname: "www.sub.domain.co.uk" }).split('=')[2],
+        '.domain.co.uk', 'should find correct domain');
+    equal($.cookie('c', ' v', { domain: "all", hostname: "domain.co.uk" }).split('=')[2],
+        '.domain.co.uk', 'should find correct domain');
+    equal($.cookie('c', ' v', { domain: "all", hostname: "www.domain.com" }).split('=')[2],
+        '.domain.com', 'should find correct domain');
+});
+
 
 module('delete', before);
 


### PR DESCRIPTION
This functionality is present in various server-side frameworks (e.g. Rails) and can be quite useful - especially if your site run on multiple TLDs which in turn has several subdomains.
