### PR TITLE
convert pluses to spaces when decoding cookies

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -36,7 +36,10 @@
 
         // key and possibly options given, get cookie...
         options = value || {};
-        var decode = options.raw ? function(s) { return s; } : decodeURIComponent;
+
+        var decode = function(s) {
+            return options.raw ? s : decodeURIComponent((s || '').replace(/\+/g, ' '));
+        };
 
         var pairs = document.cookie.split('; ');
         for (var i = 0, pair; pair = pairs[i] && pairs[i].split('='); i++) {

--- a/test.js
+++ b/test.js
@@ -30,8 +30,13 @@ test('decode', 1, function () {
 });
 
 test('raw: true', 1, function () {
-    document.cookie = 'c=%20v';
-    equal($.cookie('c', { raw: true }), '%20v', 'should not decode');
+    document.cookie = 'c=%20v+';
+    equal($.cookie('c', { raw: true }), '%20v+', 'should not decode');
+});
+
+test('convert pluses to spaces', 1, function () {
+    document.cookie = 'c=a+b';
+    equal($.cookie('c'), 'a b', 'should convert plus to space');
 });
 
 


### PR DESCRIPTION
This fix will let you set cookies with PHP's `setcookie()` method (and probably other languages too), and see spaces as spaces (previously they were plus signs).
