### PR TITLE
Allow expires to take other units of time

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -22,9 +22,27 @@
                 var days = options.expires, t = options.expires = new Date();
                 t.setDate(t.getDate() + days);
             }
-
+            else if (typeof options.expires === 'object') {
+              var expiry = options.expires, t = new Date();
+              for (var k in expiry) {
+                 switch(k) {
+                 case 'days':
+                   t.setDate(t.getDate() + expiry[k]);
+                   break;
+                 case 'hours':
+                   t = new Date(t.setHours(t.getHours() + expiry[k]));
+                   break;
+                 case 'minutes':
+                   t = new Date(t.setMinutes(t.getMinutes() + expiry[k]));
+                   break;
+                 case 'seconds':
+                   t = new Date(t.setSeconds(t.getSeconds() + expiry[k]));
+                   break;
+                 }
+              }
+              options.expires = t;
+            }
             value = String(value);
-
             return (document.cookie = [
                 encodeURIComponent(key), '=', options.raw ? value : encodeURIComponent(value),
                 options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ test('empty value', 1, function () {
     equal($.cookie('c'), '', 'should return value');
 });
 
-test('simple value with expires', 1, function () {
+test('simple value with an expires value', 1, function () {
   var tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 5);
     document.cookie = 'c=testcookie; expires=' + tomorrow.toUTCString();
@@ -64,17 +64,38 @@ test('number', 1, function() {
     equal($.cookie('c'), '1234', 'should write value');
 });
 
-test('with expires 7 days from now', 1, function() {
+test('with expires as a number (7 days from now)', 1, function() {
   var seven_days_from_now = new Date();
   seven_days_from_now.setDate(seven_days_from_now.getDate() + 7);
   equal($.cookie('c', 'v', {expires:7}), 'c=v; expires='+seven_days_from_now.toUTCString(), 'should return the cookie string with expires');
 });
 
-test('with expires yesterday', 2, function() {
+test('with expires as a negative number (yesterday)', 2, function() {
   var yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
   equal($.cookie('c', 'v', {expires:-1}), 'c=v; expires='+yesterday.toUTCString(), 'should return the cookie string with expires');
   equal(document.cookie, '', 'should not save expired cookie');
+});
+
+test('with expires as an object ({hours:1, minutes:2, seconds:3, days:4})',1, function() {
+  var expiry = {
+    hours:1, 
+    minutes:2, 
+    days:4
+  };
+  var expected_expiry = new Date();
+  expected_expiry = new Date(expected_expiry.setHours(expected_expiry.getHours() + expiry.hours));
+  expected_expiry = new Date(expected_expiry.setMinutes(expected_expiry.getMinutes() + expiry.minutes));
+  expected_expiry.setDate(expected_expiry.getDate() + expiry.days);
+  equal($.cookie('c', 'v', {expires:expiry}), 'c=v; expires='+expected_expiry.toUTCString(), 'should return the cookie string with expires');
+});
+
+test('with expires as an object - ignores garbage ({myhours:1})',1, function() {
+  var expiry = {
+    myhours: 10 
+  };
+  var expected_expiry = new Date();
+  equal($.cookie('c', 'v', {expires:expiry}), 'c=v; expires='+expected_expiry.toUTCString(), 'should return the cookie string with expires');
 });
 
 test('return value', 1, function () {


### PR DESCRIPTION
I needed to get cookies to expire on shorter time scales than 1 day.  I've added the ability to pass in a hash to specify expires with the following allowed keys [ days, hours, minutes, seconds ].  I also added tests for this.  

Again, feel free to add or not.  

Cheers
Mr Rogers
