### PR TITLE
Cookies containing '=' work as well.

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -39,7 +39,7 @@
         var decode = options.raw ? function(s) { return s; } : decodeURIComponent;
 
         var pairs = document.cookie.split('; ');
-        for (var i = 0, pair; pair = pairs[i] && pairs[i].split('='); i++) {
+        for (var i = 0, pair; pair = pairs[i] && pairs[i].split(/=(.+)?/); i++) {
             if (decode(pair[0]) === key) return decode(pair[1] || ''); // IE saves cookies with empty string as "c; ", e.g. without "=" as opposed to EOMB, thus pair[1] may be undefined
         }
         return null;


### PR DESCRIPTION
The cookies containing '=' didn't work properly since the cookie value is splited against '='.

Example:

cookie => 'apple=abcdefgh=;' // which is the case with most of the Base64 encoded strings stored in cookie because of the padding =.
