### PR TITLE
== null checks for null and undefined

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -11,10 +11,10 @@
     $.cookie = function(key, value, options) {
 
         // key and at least value given, set cookie...
-        if (arguments.length > 1 && (!/Object/.test(Object.prototype.toString.call(value)) || value === null || value === undefined)) {
+        if (arguments.length > 1 && (!/Object/.test(Object.prototype.toString.call(value)) || value == null)) {
             options = $.extend({}, $.cookie.defaults, options);
 
-            if (value === null || value === undefined) {
+            if (value == null) {
                 options.expires = -1;
             }
 


### PR DESCRIPTION
"It's actually quite useful to do == null or != null as it will pass (or
fail) if the value is either null or undefined."
http://docs.jquery.com/JQuery_Core_Style_Guidelines
