### PR TITLE
Add for human friendly units of expires days

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -37,8 +37,8 @@
             }
             
             if (typeof options.expires !=='undefined' && typeof options.expires !== 'number') {
-                if ($.inArray(options.expires.substr(-1),options.vailidUnits) > -1 ){
-                    options.expiresUnit = options.expires.substr(-1);
+                if ($.inArray(options.expires.substr(options.expires.length-1),options.vailidUnits) > -1 ){
+                    options.expiresUnit = options.expires.substr(options.expires.length-1);
                     options.expires = parseInt(options.expires);
                 }
             }


### PR DESCRIPTION
- fork by ihipop @ 15:56 2012-07-10 
  - Add for human friendly units of expires days
  - now these methods are accessable
  -  jQuery.cookie('test',123,{expires:'0s'})
  - "test=123; expires=Tue, 10 Jul 2012 08:00:01 GMT"
  -  jQuery.cookie('test',123,{expires:'1m'})
  - "test=123; expires=Tue, 10 Jul 2012 08:01:08 GMT"
  -  jQuery.cookie('test',123,{expires:'1h'})
  - "test=123; expires=Tue, 10 Jul 2012 09:00:14 GMT"
  -  jQuery.cookie('test',123,{expires:'1d'})
  - "test=123; expires=Wed, 11 Jul 2012 08:00:17 GMT"
  -  jQuery.cookie('test',123,{expires:'1'})
  - TypeError: Object 1 has no method 'toUTCString'
  -  jQuery.cookie('test',123,{expires:1})
  - "test=123; expires=Wed, 11 Jul 2012 08:00:50 GMT"
    */
