### PR TITLE
Modified "expires" option to support unixtimestamp.

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -1,6 +1,6 @@
 /*jshint eqnull:true */
 /*!
- * jQuery Cookie Plugin v1.1
+ * jQuery Cookie Plugin v1.1.1
  * https://github.com/carhartl/jquery-cookie
  *
  * Copyright 2011, Klaus Hartl
@@ -28,10 +28,15 @@
 				options.expires = -1;
 			}
 
-			if (typeof options.expires === 'number') {
-				var days = options.expires, t = options.expires = new Date();
-				t.setDate(t.getDate() + days);
-			}
+		    if (typeof options.expires === 'number') {
+					if(options.expires > Math.round((new Date()).getTime()/1000)) {
+						var unixts = options.expires, t = options.expires = new Date();
+						t.setTime((unixts*1000));
+					} else {
+						var days = options.expires, t = options.expires = new Date();
+						t.setDate(t.getDate() + days);
+					}
+		    }
 
 			value = String(value);
 


### PR DESCRIPTION
Hi,

I just made a simple modification to the "expires" option.

If options.expires is set to a unixtimestamp that is greater than the current unixtimestamp the cookie will be set to expire exactly at that time, and not X days from now.

Use it if you like.

Best regards,
Henrik Urlund
http://urlund.com 
