### PR TITLE
Feature: Allow the storage of objects. Degrades gracefully.

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -23,7 +23,7 @@
 	$.cookie = function (key, value, options) {
 
 		// key and at least value given, set cookie...
-		if (value !== undefined && !/Object/.test(Object.prototype.toString.call(value))) {
+		if (value !== undefined && (JSON !== undefined || !/Object/.test(Object.prototype.toString.call(value))) ) {
 			options = $.extend({}, $.cookie.defaults, options);
 
 			if (value === null) {
@@ -35,7 +35,7 @@
 				t.setDate(t.getDate() + days);
 			}
 
-			value = String(value);
+			value = JSON !== undefined ? JSON.stringify(value) : String(value);
 
 			return (document.cookie = [
 				encodeURIComponent(key), '=', options.raw ? value : encodeURIComponent(value),
@@ -52,7 +52,8 @@
 		var cookies = document.cookie.split('; ');
 		for (var i = 0, parts; (parts = cookies[i] && cookies[i].split('=')); i++) {
 			if (decode(parts.shift()) === key) {
-				return decode(parts.join('='));
+				var cookie = decode(parts.join('='));
+				return JSON !== undefined ? JSON.parse(cookie) : cookie;
 			}
 		}
 


### PR DESCRIPTION
Allow the storage of objects in cookies. Degrades gracefully. Older browser support with crockford's JSON.js (https://github.com/douglascrockford/JSON-js)

In Dev Tools:

``` javascript
$.cookie('foo')
42
$.cookie('foo',{bar: 42})
"foo=%7B%22bar%22%3A42%7D"
$.cookie('foo')
Object
    bar: 42
    __proto__: Object
$.cookie('bar')
null
```
