### PR TITLE
Explicitly set defaults.path

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -34,7 +34,7 @@
 				var days = options.expires, t = options.expires = new Date();
 				t.setDate(t.getDate() + days);
 			}
-
+			
 			value = config.json ? JSON.stringify(value) : String(value);
 
 			return (document.cookie = [
@@ -59,7 +59,7 @@
 		return null;
 	};
 
-	config.defaults = {};
+	config.defaults = {path: document.location.pathname};
 
 	$.removeCookie = function (key, options) {
 		if ($.cookie(key) !== null) {


### PR DESCRIPTION
My site has urls:

http://www.essaytagger.com/commoncore/step1
http://www.essaytagger.com/commoncore/step2?ccgradeLevel_id=4
etc.

The default cookie path was being stored as: "/commoncore".

I'm using the same cookie name on each page to track whether or not the user has seen the popup guided tour ('has_seen_guider').

This resulted in cookie collisions/overwrites for all pages under the /commoncore dir.

Explicitly setting:

```
 config.defaults = {path: document.location.pathname};
```

has cleared up the issue for me. Now I see the correct paths for each cookie:

'/commoncore/step1'
'/commoncore/step2'
etc.

I don't confess to fully understanding the cookie mechanism, but this patch seemed straightforward to me. Tested on Mac with Chrome, Firefox, and Safari.

Your thoughts?
