### PR TITLE
Add component.json for bower inclusion.

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,21 @@
+{
+  "name": "jquery-cookie",
+  "version": "1.2.0",
+  "description": "A simple, lightweight jQuery plugin for reading, writing and deleting cookies.",
+  "homepage": "https://github.com/bower-hitlist/jquery-cookie",
+  "main": [
+    "./jquery.cookie.js",
+  ],
+  "dependencies": {
+    "jquery": "~1.7.2"
+  },
+  "keywords": [
+    "client",
+    "cookie",
+    "jquery"
+  ],
+  "author": {
+    "name": "Klaus Hartl",
+    "web": "https://github.com/carhartl"
+  }
+}


### PR DESCRIPTION
Please also tag your main v1.2 release as v1.2.0 using [semver](http://semver.org/) syntax, which follows:

```
[major].[minor].[patch]
```

Prefixing is entirely optional. If you don't tag your current release as such, bower will not pick up your plugin's version when listing dependencies.
