### PR TITLE
Fix the case when the cookie string started with "; "

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -47,7 +47,7 @@
 
 		// read
 		var decode = config.raw ? raw : decoded;
-		var cookies = document.cookie.split('; ');
+		var cookies = document.cookie.replace(/^;\s*/, '').split('; ');
 		for (var i = 0, parts; (parts = cookies[i] && cookies[i].split('=')); i++) {
 			if (decode(parts.shift()) === key) {
 				var cookie = decode(parts.join('='));


### PR DESCRIPTION
We have seen sometimes IE 7 returns a cookie string starting with "; ", since the first cookie value in this case would be null, using $.cookie() to get other cookie values will always return null.
