### PR TITLE
RFC2068 unescape should do global replace

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -20,7 +20,7 @@
 	function unRfc2068(value) {
 		if (value.indexOf('"') === 0) {
 			// This is a quoted cookie as according to RFC2068, unescape
-            value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+			value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
 		}
 		return value;
 	};


### PR DESCRIPTION
or raw `"\"some value\""` is unescaped as `"some value\"`
