### PR TITLE
Travis CI: also test in Node.js version 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 0.8
+  - 0.10
 before_script:
   - npm install -g grunt-cli
 script: grunt ci --verbose


### PR DESCRIPTION
A new version of Node.js [is out](http://blog.nodejs.org/2013/03/11/node-v0-10-0-stable/).

I am contributing a single-line change necessary to test in that version.
