### PR TITLE
support setting null to remove cookie.. 

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -36,7 +36,9 @@
 	}
 
 	var config = $.cookie = function (key, value, options) {
-
+		if(value === null){
+			$.removeCookie(key, options);
+		}
 		// write
 		if (value !== undefined) {
 			options = $.extend({}, config.defaults, options);


### PR DESCRIPTION
Updated jquery.cookie.js to be backwards compatible so when setting null it removes the cookie...
internally it calls $.removeCookie(); 
