### PR TITLE
Fix: invalid cookie causes unhandled exception

### DIFF
--- a/jquery.cookie.js
+++ b/jquery.cookie.js
@@ -21,7 +21,12 @@
 		if (config.raw) {
 			return s;
 		}
-		return decodeURIComponent(s.replace(pluses, ' '));
+		try {
+			return decodeURIComponent(s.replace(pluses, ' '));
+		} catch (error) {
+			// Malformed cookie?
+			return s;
+		}
 	}
 
 	function decodeAndParse(s) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -16,6 +16,12 @@ test('simple value', function () {
 	strictEqual($.cookie('c'), 'v', 'should return value');
 });
 
+test('Invalid encoding', function () {
+	expect(1);
+	document.cookie = 'c=100%';
+	strictEqual($.cookie('c'), '100%', 'should return value');
+});
+
 test('empty value', function () {
 	expect(1);
 	// IE saves cookies with empty string as "c; ", e.g. without "=" as opposed to EOMB, which


### PR DESCRIPTION
Cookies ending in "%" cause an unhandled exception.
