### PR TITLE
add jspm package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,12 @@
     "grunt-saucelabs": "~4.1.1",
     "grunt-contrib-connect": "~0.5.0",
     "gzip-js": "~0.3.0"
+  },
+  "jspm": {
+    "main": "jquery.cookie",
+    "files": ["jquery.cookie.js"],
+    "buildConfig": {
+      "uglify": true
+    }
   }
 }


### PR DESCRIPTION
With this package.json configuration, it is possible to load the plugin through jspm, like in the following example:

http://jsbin.com/Avufiyo/1/edit

The plugin is served minified with source maps over SPDY, with the AMD format automatically detected by the loader.

Would really appreciate not having to do a custom override for this functionality. Any questions just ask.
