### PR TITLE
Allow Objects and Arrays to be stored as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,37 @@ $.removeCookie('the_cookie', { path: '/' });
 
 *Note: when deleting a cookie, you must pass the exact same path, domain and secure options that were used to set the cookie, unless you're relying on the default options that is.*
 
+## JSON
+
+Objects and arrays are transparently converted to/from JSON. This consistent with the jQuery `.data()` function:
+
+- *Read:* cookies starting with `{` or `[` will be parsed with `JSON.parse()` and returned as an object or array
+- *Write:* cookies that are native objects (`foo.constructor === Object`) or arrays (`foo.constructor === Array`) will be encoded as JSON with `JSON.stringify()` and stored as strings
+
+The cookie string must follow [valid JSON syntax](http://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example) including quoted property names. If the cookie isn't parseable for any reason, it is returned as a string.
+
+Strings that are similar to JSON, such as `[test me]` are not parseable, and will be returned as strings.
+
+Storing an array or object in a cookie:
+
+```javascript
+$.cookie('the_cookie1', [1, 2, 3]); // Automatically convert the array to JSON.
+$.cookie('the_cookie2', {foo: 'bar'}); // Automatically converts the object to JSON.
+```
+
+Retrieving an object or array stored as a JSON cookie:
+
+```javascript
+var cookie1 = $.cookie('the_cookie1'); // [1, 2, 3]
+var cookie2 = $.cookie('the_cookie2'); // {foo: 'bar'}
+```
+
+**Note about backwards compatibility**
+
+The `json` configuration setting has been removed and no longer has any effect. Since JSON parsing happens transparently now, most code will require no changes. But be aware: if a cookie cannot be parsed, the `$.cookie()` will return the raw string version will now be returned, whereas previously it would return `undefined`.
+
+Because `$.cookie()` may now return an object or array, if you were previously storing JSON in a cookie and passing it to `JSON.parse()` manually, you may now end up passing an object or array into `JSON.parse()`, causing an exception.
+
 ## Configuration
 
 ### raw
@@ -77,15 +108,7 @@ By default the cookie value is encoded/decoded when writing/reading, using `enco
 $.cookie.raw = true;
 ```
 
-### json
-
-Turn on automatic storage of JSON objects passed as the cookie value. Assumes `JSON.stringify` and `JSON.parse`:
-
-```javascript
-$.cookie.json = true;
-```
-
-## Cookie Options
+## Cookie options
 
 Cookie attributes can be set globally by setting properties of the `$.cookie.defaults` object or individually for each call to `$.cookie()` by passing a plain object to the options argument. Per-call options override the default options.
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -71,6 +71,28 @@ test('json = true', function () {
 	}
 });
 
+test('Arrays are saved and returned correctly', function () {
+	expect(1);
+
+	if ('JSON' in window) {
+		$.cookie('c', ['foo', 'bar']);
+		deepEqual($.cookie('c'), ['foo', 'bar'], 'Array was not saved and returned correctly');
+	} else {
+		ok(true);
+	}
+});
+
+test('Objects are saved and returned correctly', function () {
+	expect(1);
+
+	if ('JSON' in window) {
+		$.cookie('c', { foo: 'bar' });
+		deepEqual($.cookie('c'), { foo: 'bar' }, 'Object was not saved and returned correctly');
+	} else {
+		ok(true);
+	}
+});
+
 test('not existing with json = true', function () {
 	expect(1);
 
@@ -94,18 +116,6 @@ test('string with json = true', function () {
 	}
 });
 
-test('invalid JSON string with json = true', function () {
-	expect(1);
-
-	if ('JSON' in window) {
-		$.cookie('c', 'v');
-		$.cookie.json = true;
-		strictEqual($.cookie('c'), undefined, "won't throw exception, returns undefined");
-	} else {
-		ok(true);
-	}
-});
-
 test('invalid URL encoding', function () {
 	expect(1);
 	document.cookie = 'bad=foo%';
@@ -113,6 +123,30 @@ test('invalid URL encoding', function () {
 	// Delete manually here because it requires raw === true...
 	$.cookie.raw = true;
 	$.removeCookie('bad');
+});
+
+// Make sure a URL encoded JSON Object cookie gets returned as an object
+test('cookie containing URL encoded JSON Object', function () {
+	expect(1);
+
+	if ('JSON' in window) {
+		document.cookie = 'foo=%7B%22bar%22%3A42%7D';
+		deepEqual($.cookie('foo'), { bar: 42 }, 'cookie containing URL encoded JSON Object did not get parsed correctly');
+	} else {
+		ok(true);
+	}
+});
+
+// Make sure a URL encoded JSON Array cookie gets returned as an object
+test('cookie containing URL encoded JSON Array', function () {
+	expect(1);
+
+	if ('JSON' in window) {
+		document.cookie = 'foo=%5B%22foo%22%2C%20%22bar%22%5D';
+		deepEqual($.cookie('foo'), ['foo', 'bar'], 'cookie containing URL encoded JSON Array did not get parsed correctly');
+	} else {
+		ok(true);
+	}
 });
 
 asyncTest('malformed cookie value in IE (#88, #117)', function () {
@@ -141,12 +175,6 @@ test('Call to read all when there are cookies', function () {
 
 test('Call to read all when there are no cookies at all', function () {
 	deepEqual($.cookie(), {}, 'returns empty object');
-});
-
-test('Call to read all with json: true', function () {
-	$.cookie.json = true;
-	$.cookie('c', { foo: 'bar' });
-	deepEqual($.cookie(), { c: { foo: 'bar' } }, 'returns JSON parsed cookies');
 });
 
 test('Call to read all with a badly encoded cookie', function () {
@@ -240,7 +268,34 @@ test('json = true', function () {
 
 	if ('JSON' in window) {
 		$.cookie('c', { foo: 'bar' });
-		strictEqual(document.cookie, 'c=' + encodeURIComponent(JSON.stringify({ foo: 'bar' })), 'should stringify JSON');
+		strictEqual(document.cookie, 'c=' + encodeURIComponent(JSON.stringify({ foo: 'bar' })),
+			'should stringify JSON');
+	} else {
+		ok(true);
+	}
+});
+
+// Objects saved in cookies should be stringified as JSON.
+test('Objects are stringified', function () {
+	expect(1);
+
+	if ('JSON' in window) {
+		$.cookie('c', { foo: 'bar' });
+		strictEqual(document.cookie, 'c=' + encodeURIComponent(JSON.stringify({ foo: 'bar' })),
+			'should stringify Object objects');
+	} else {
+		ok(true);
+	}
+});
+
+// Arrays saved in cookies should be stringified as JSON.
+test('Arrays are stringified', function () {
+	expect(1);
+
+	if ('JSON' in window) {
+		$.cookie('c', ['foo', 'bar']);
+		strictEqual(document.cookie, 'c=' + encodeURIComponent(JSON.stringify(['foo', 'bar'])),
+			'should stringify Array objects');
 	} else {
 		ok(true);
 	}


### PR DESCRIPTION
Continued from #283

Messed up the previous pull request, so I've made a fresh clean one. This one also removes the `json` configuration directive, in favour of the automatic JSON object and array parsing.

README updated to reflect the new behaviour. Tests updated, and additional tests added to test new functionality.