### PR TITLE
Removed var duplication, cached cookies.length

### DIFF
--- a/src/jquery.cookie.js
+++ b/src/jquery.cookie.js
@@ -75,19 +75,20 @@
 
 		// Read
 
-		var result = key ? undefined : {};
+		var result = key ? undefined : {},
 
 		// To prevent the for loop in the first place assign an empty array
 		// in case there are no cookies at all. Also prevents odd result when
 		// calling $.cookie().
-		var cookies = document.cookie ? document.cookie.split('; ') : [];
+			cookies = document.cookie ? document.cookie.split('; ') : [],
+			i = 0, l = cookies.length;
 
-		for (var i = 0, l = cookies.length; i < l; i++) {
-			var parts = cookies[i].split('=');
-			var name = decode(parts.shift());
-			var cookie = parts.join('=');
+		for (; i < l; i++) {
+			var parts = cookies[i].split('='),
+				name = decode(parts.shift()),
+				cookie = parts.join('=');
 
-			if (key && key === name) {
+			if (key === name) {
 				// If second argument (value) is a function it's a converter...
 				result = read(cookie, value);
 				break;


### PR DESCRIPTION
Always good to save a couple of bytes where possible, multiple vars may not be stripped during minify so lets do it now

Calculate length before the forLoop is initiated, can be faster in extreme cases or when you need max performance - see http://jsperf.com/angular-foreach-vs-native-for-loop/29