### PR TITLE
travis: Fix constant build failure for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: node_js
 node_js:
-  - 0.10
+  - '0.10'
 before_script:
   - npm install -g grunt-cli
-script: grunt ci --verbose
+# Only use grunt-ci for commits pushed to this repo. Fall back to regular test
+# for pull requests (as secure variables won't be exposed there).
+script: |
+  test $SAUCE_ACCESS_KEY == 'false' && grunt ci --verbose || npm test
 env:
   global:
     - secure: HRae0kyIDDuhonvMi2SfEl1WJb4K/wX8WmzT9YkxFbmWwLjiOMkmqyuEyi76DbTC1cb9o7WwGVgbP1DhSm6n6m0Lz+PSzpprBN4QZuJc56jcc+tBA6gM81hyUufaTT0yUWz112Bu06kWIAs44w5PtG0FYZR0CuIN8fQvZi8fXCQ=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,11 @@ module.exports = function (grunt) {
 		}
 	}
 
-	grunt.registerTask('default', ['jshint', 'qunit', 'uglify', 'compare_size']);
 	grunt.registerTask('saucelabs', ['connect:saucelabs', 'saucelabs-qunit']);
-	grunt.registerTask('ci', ['jshint', 'qunit', 'saucelabs']);
+	grunt.registerTask('test', ['jshint', 'qunit']);
+
+	grunt.registerTask('dev', ['test', 'uglify', 'compare_size']);
+	grunt.registerTask('ci', ['test', 'saucelabs']);
+
+	grunt.registerTask('default', 'dev');
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "grunt"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Only execute `grunt-ci` for authorised commits to the repo.

Use plain `npm-test` for pull requests (like one would locally).

----

Also fixed the nodejs version number to be a string because software version numbers cannot be represented in decimal numbers ([documentation](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/) / issue travis-ci/travis-ci#977). Passing 0.10 as a number used to cause Travis to actually spawn an ancient nodejs 0.1 vm. While it no longer does that, it's still fragile to rely on and best to avoid similar problems in the future.