### PR TITLE
Add try-catch block around cookie name decoding

### DIFF
--- a/src/jquery.cookie.js
+++ b/src/jquery.cookie.js
@@ -83,20 +83,22 @@
 		var cookies = document.cookie ? document.cookie.split('; ') : [];
 
 		for (var i = 0, l = cookies.length; i < l; i++) {
-			var parts = cookies[i].split('=');
-			var name = decode(parts.shift());
-			var cookie = parts.join('=');
+			try {
+				var parts = cookies[i].split('=');
+				var name = decode(parts.shift());
+				var cookie = parts.join('=');
 
-			if (key && key === name) {
-				// If second argument (value) is a function it's a converter...
-				result = read(cookie, value);
-				break;
-			}
+				if (key && key === name) {
+					// If second argument (value) is a function it's a converter...
+					result = read(cookie, value);
+					break;
+				}
 
-			// Prevent storing a cookie that we couldn't decode.
-			if (!key && (cookie = read(cookie)) !== undefined) {
-				result[name] = cookie;
-			}
+				// Prevent storing a cookie that we couldn't decode.
+				if (!key && (cookie = read(cookie)) !== undefined) {
+					result[name] = cookie;
+				}
+			catch(e) {}
 		}
 
 		return result;


### PR DESCRIPTION
Stops differently encoded cookies from causing trouble (they won't work with `$.cookie` but they won't break all other cookies as well). Partially fixes #294.
