### PR TITLE
Added 'enabled' function

### DIFF
--- a/src/jquery.cookie.js
+++ b/src/jquery.cookie.js
@@ -102,6 +102,17 @@
 		return result;
 	};
 
+	$.cookie.enabled = (function() {
+		var enabled = navigator.cookieEnabled;
+
+		if(typeof enabled === undefined && !enabled) {
+			document.cookie = 'test';
+			enabled = (document.cookie.indexOf('test') !== -1) ? true : false;
+		}
+
+		return enabled;
+	})();
+
 	config.defaults = {};
 
 	$.removeCookie = function (key, options) {
@@ -113,5 +124,4 @@
 		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
 		return !$.cookie(key);
 	};
-
 }));

--- a/test/tests.js
+++ b/test/tests.js
@@ -43,6 +43,11 @@ test('RFC 2068 quoted string', function () {
 	strictEqual($.cookie('c'), 'v@address.com"\\"', 'should decode RFC 2068 quoted string');
 });
 
+test('Check if enabled property returns boolean', function () {
+	expect(1);
+	strictEqual($.cookie.enabled, true || false, 'should return a boolean value');
+});
+
 test('decode', function () {
 	expect(1);
 	document.cookie = encodeURIComponent(' c') + '=' + encodeURIComponent(' v');


### PR DESCRIPTION
This will allow users of the library to quickly check if cookies are enabled on the client without having to maintain an external function to do it for them.

    $.cookie.enabled //returns a boolean to check

A `boolean` value check was also added to the unit tests