### PR TITLE
Clarified usage of json property

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $.cookie.raw = true;
 
 ### json
 
-Turn on automatic storage of JSON objects passed as the cookie value. Performs `JSON.stringify` and `JSON.parse` when writing and reading the cookie:
+Turn on automatic storage of JSON objects passed as the cookie value. Executes `JSON.stringify` and `JSON.parse` when writing and reading the cookie respectively:
 
 ```javascript
 $.cookie.json = true;

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $.cookie.raw = true;
 
 ### json
 
-Turn on automatic storage of JSON objects passed as the cookie value. Assumes `JSON.stringify` and `JSON.parse`:
+Turn on automatic storage of JSON objects passed as the cookie value. Performs `JSON.stringify` and `JSON.parse` when writing and reading the cookie:
 
 ```javascript
 $.cookie.json = true;


### PR DESCRIPTION
The line "Assumes 'JSON.stringify' and 'JSON.parse'" could be interpreted as: Assumes the user executes these functions before passing $.cookie the data.  Rather than Assumes the task of executing these functions when $.cookie is called.
