### PR TITLE
Adding license info to the bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery.cookie",
   "version": "1.4.1",
+  "license": "MIT",
   "main": [
     "src/jquery.cookie.js"
   ],


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the bower.json tools like VersionEye can fetch it easier.